### PR TITLE
Remove callback group for topics and services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release Versions:
 
 ## Upcoming changes (in development)
 
+- Remove callback group for topics and services (#61)
 - Avoid conflict with get_parameter (#42)
 - Revise ComponentInterface by moving implementations to source file (#39)
 - Update component classes to inherit from new ComponentInterface (#38)

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -552,7 +552,6 @@ private:
   std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle>
       parameter_cb_handle_; ///< ROS callback function handle for setting parameters
 
-  std::shared_ptr<rclcpp::CallbackGroup> cb_group_;
   std::shared_ptr<rclcpp::TimerBase> step_timer_; ///< Timer for the step function
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_; ///< TF buffer
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_; ///< TF listener

--- a/source/modulo_components/src/ComponentInterface.cpp
+++ b/source/modulo_components/src/ComponentInterface.cpp
@@ -22,7 +22,6 @@ ComponentInterface::ComponentInterface(
     node_services_(interfaces->get_node_services_interface()),
     node_timers_(interfaces->get_node_timers_interface()),
     node_topics_(interfaces->get_node_topics_interface()) {
-  this->cb_group_ = node_base_->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
   // register the parameter change callback handler
   this->parameter_cb_handle_ = this->node_parameters_->add_on_set_parameters_callback(
       [this](const std::vector<rclcpp::Parameter>& parameters) -> rcl_interfaces::msg::SetParametersResult {
@@ -38,7 +37,7 @@ ComponentInterface::ComponentInterface(
 
   this->step_timer_ = rclcpp::create_wall_timer(
       std::chrono::nanoseconds(static_cast<int64_t>(this->get_parameter_value<double>("period") * 1e9)),
-      [this] { this->step(); }, this->cb_group_, this->node_base_.get(), this->node_timers_.get());
+      [this] { this->step(); }, nullptr, this->node_base_.get(), this->node_timers_.get());
 }
 
 void ComponentInterface::step() {}
@@ -347,7 +346,7 @@ void ComponentInterface::add_service(
             response->success = false;
             response->message = ex.what();
           }
-        }, this->qos_, this->cb_group_);
+        }, this->qos_, nullptr);
     this->empty_services_.insert_or_assign(parsed_service_name, service);
   } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(this->node_logging_->get_logger(),
@@ -374,7 +373,7 @@ void ComponentInterface::add_service(
             response->success = false;
             response->message = ex.what();
           }
-        }, this->qos_, this->cb_group_);
+        }, this->qos_, nullptr);
     this->string_services_.insert_or_assign(parsed_service_name, service);
   } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(this->node_logging_->get_logger(),


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
This PR finally solves the problem with unloading components after the component interface refactor. It's been some time since we last worked on this but I rebased the 'iron' branch (the branch that has the 4 commits regarding the component interface refactor with node interfaces) and found that the issue with that was just an additional callback group that I created for I don't know what reason and that group was responsible for the issues when removing the component from the executor.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->