### PR TITLE
refactor: move utilities to modulo_utils package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Release Versions:
 - build: change base workspace image version
 - refactor: rename function in modulo translators (#77)
 - feat: add mutex around step callback (#67)
+- refactor: move utilities to modulo_utils package (#89)
 
 ## 4.1.0
 

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -18,10 +18,12 @@
 #include <modulo_component_interfaces/srv/string_trigger.hpp>
 #include <modulo_component_interfaces/msg/predicate.hpp>
 
+#include <modulo_utils/parsing.hpp>
+#include <modulo_utils/predicate_variant.hpp>
+
 #include "modulo_components/exceptions/AddSignalException.hpp"
 #include "modulo_components/exceptions/ComponentParameterException.hpp"
 #include "modulo_components/utilities/utilities.hpp"
-#include "modulo_components/utilities/predicate_variant.hpp"
 
 /**
  * @namespace modulo_components
@@ -464,14 +466,14 @@ private:
    * @param name The name of the predicate
    * @param predicate The predicate variant
    */
-  void add_variant_predicate(const std::string& name, const utilities::PredicateVariant& predicate);
+  void add_variant_predicate(const std::string& name, const modulo_utils::PredicateVariant& predicate);
 
   /**
    * @brief Set the predicate given as parameter, if the predicate is not found does not do anything.
    * @param name The name of the predicate
    * @param predicate The predicate variant
    */
-  void set_variant_predicate(const std::string& name, const utilities::PredicateVariant& predicate);
+  void set_variant_predicate(const std::string& name, const modulo_utils::PredicateVariant& predicate);
 
   /**
    * @brief Declare a signal to create the topic parameter without adding it to the map of signals.
@@ -538,7 +540,7 @@ private:
 
   std::mutex step_mutex_; ///< Mutex for step callback
 
-  std::map<std::string, utilities::PredicateVariant> predicates_; ///< Map of predicates
+  std::map<std::string, modulo_utils::PredicateVariant> predicates_; ///< Map of predicates
   std::shared_ptr<rclcpp::Publisher<modulo_component_interfaces::msg::Predicate>>
       predicate_publisher_; ///< Predicate publisher
   std::map<std::string, bool> triggers_; ///< Map of triggers
@@ -630,7 +632,7 @@ inline void ComponentInterface::add_input(
           "Invalid data pointer for input '" + signal_name + "'.");
     }
     this->declare_input(signal_name, default_topic, fixed_topic);
-    std::string parsed_signal_name = utilities::parse_topic_name(signal_name);
+    std::string parsed_signal_name = modulo_utils::parse_topic_name(signal_name);
     auto topic_name = this->get_parameter_value<std::string>(parsed_signal_name + "_topic");
     RCLCPP_DEBUG_STREAM(this->node_logging_->get_logger(),
                         "Adding input '" << parsed_signal_name << "' with topic name '" << topic_name << "'.");
@@ -701,7 +703,7 @@ inline void ComponentInterface::add_input(
 ) {
   using namespace modulo_core::communication;
   try {
-    std::string parsed_signal_name = utilities::parse_topic_name(signal_name);
+    std::string parsed_signal_name = modulo_utils::parse_topic_name(signal_name);
     this->declare_input(parsed_signal_name, default_topic, fixed_topic);
     auto topic_name = this->get_parameter_value<std::string>(parsed_signal_name + "_topic");
     RCLCPP_DEBUG_STREAM(this->node_logging_->get_logger(),
@@ -724,7 +726,7 @@ inline std::string ComponentInterface::create_output(
 ) {
   using namespace modulo_core::communication;
   try {
-    auto parsed_signal_name = utilities::parse_topic_name(signal_name);
+    auto parsed_signal_name = modulo_utils::parse_topic_name(signal_name);
     if (data == nullptr) {
       throw modulo_core::exceptions::NullPointerException(
           "Invalid data pointer for output '" + parsed_signal_name + "'.");

--- a/source/modulo_components/include/modulo_components/utilities/utilities.hpp
+++ b/source/modulo_components/include/modulo_components/utilities/utilities.hpp
@@ -11,58 +11,6 @@
 namespace modulo_components::utilities {
 
 /**
- * @brief Parse a string argument value from an argument list given a pattern prefix.
- * @param args a vector of string arguments
- * @param pattern the prefix pattern to find and strip
- * @param result the default argument value that is overwritten by reference if the given pattern is found
- * @return the value of the resultant string
- */
-[[maybe_unused]] static std::string
-parse_string_argument(const std::vector<std::string>& args, const std::string& pattern, std::string& result) {
-  for (const auto& arg : args) {
-    std::string::size_type index = arg.find(pattern);
-    if (index != std::string::npos) {
-      result = arg;
-      result.erase(index, pattern.length());
-      break;
-    }
-  }
-  return result;
-}
-
-/**
- * @brief Parse a string node name from NodeOptions arguments.
- * @param options the NodeOptions structure to parse
- * @param fallback the default name if the NodeOptions structure cannot be parsed
- * @return the parsed node name or the fallback name
- */
-[[maybe_unused]]  static std::string
-parse_node_name(const rclcpp::NodeOptions& options, const std::string& fallback = "") {
-  std::string node_name(fallback);
-  const std::string pattern("__node:=");
-  return parse_string_argument(options.arguments(), pattern, node_name);
-}
-
-/**
- * @brief Parse a string topic name from a user-provided input.
- * @details This functions removes all characters different from
- * a-z, A-Z, 0-9, and _ from a string.
- * @param topic_name The input string
- * @return The sanitized string
- */
-[[maybe_unused]] static std::string parse_topic_name(const std::string& topic_name) {
-  std::string output;
-  for (char c : topic_name) {
-    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
-      output.insert(output.end(), std::tolower(c));
-    } else if (!output.empty() && ((c >= '0' && c <= '9') || c == '_')) {
-      output.insert(output.end(), std::tolower(c));
-    }
-  }
-  return output;
-}
-
-/**
  * @brief Modify parameter overrides to handle the rate and period parameters
  * @details This function checks for existence of the rate and period parameter in the parameter overrides
  * and modifies them to correspond to the same value. If both the rate and the period parameter exist, the period will

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -11,9 +11,10 @@ import state_representation as sr
 from geometry_msgs.msg import TransformStamped
 from modulo_component_interfaces.msg import Predicate
 from modulo_component_interfaces.srv import EmptyTrigger, StringTrigger
+from modulo_utils.parsing import parse_topic_name
 from modulo_components.exceptions import AddServiceError, AddSignalError, ComponentError, ComponentParameterError, \
     LookupTransformError
-from modulo_components.utilities import parse_topic_name, modify_parameter_overrides
+from modulo_components.utilities import modify_parameter_overrides
 from modulo_core import EncodedState
 from modulo_core.exceptions import MessageTranslationError, ParameterTranslationError
 from modulo_core.translators.parameter_translators import get_ros_parameter_type, read_parameter_const, write_parameter

--- a/source/modulo_components/modulo_components/utilities/__init__.py
+++ b/source/modulo_components/modulo_components/utilities/__init__.py
@@ -1,1 +1,1 @@
-from modulo_components.utilities.utilities import parse_topic_name, modify_parameter_overrides
+from modulo_components.utilities.utilities import modify_parameter_overrides

--- a/source/modulo_components/modulo_components/utilities/utilities.py
+++ b/source/modulo_components/modulo_components/utilities/utilities.py
@@ -4,19 +4,6 @@ from typing import List
 from rclpy import Parameter
 
 
-def parse_topic_name(topic_name: str) -> str:
-    """
-    Parse a string topic name from a user-provided input.
-    This functions removes all characters different from a-z, A-Z, 0-9, and _ from a string.
-
-    :param topic_name: The input string
-    :return: The sanitized string
-    """
-    sanitized_string = re.sub("\W", "", topic_name, flags=re.ASCII).lower()
-    sanitized_string = sanitized_string.lstrip("0123456789_")
-    return sanitized_string
-
-
 def modify_parameter_overrides(parameter_overrides: List[Parameter]) -> List[Parameter]:
     """
     Modify parameter overrides to handle the rate and period parameters.

--- a/source/modulo_components/src/Component.cpp
+++ b/source/modulo_components/src/Component.cpp
@@ -7,7 +7,7 @@ namespace modulo_components {
 
 Component::Component(const NodeOptions& node_options, const std::string& fallback_name)
     : Node(
-        utilities::parse_node_name(node_options, fallback_name), utilities::modify_parameter_overrides(node_options)),
+        modulo_utils::parse_node_name(node_options, fallback_name), utilities::modify_parameter_overrides(node_options)),
       ComponentInterface(std::make_shared<node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES>>(
           Node::get_node_base_interface(), Node::get_node_clock_interface(), Node::get_node_graph_interface(),
           Node::get_node_logging_interface(), Node::get_node_parameters_interface(),

--- a/source/modulo_components/src/ComponentInterface.cpp
+++ b/source/modulo_components/src/ComponentInterface.cpp
@@ -162,14 +162,15 @@ ComponentInterface::on_validate_parameter_callback(const std::shared_ptr<state_r
 }
 
 void ComponentInterface::add_predicate(const std::string& name, bool predicate) {
-  this->add_variant_predicate(name, utilities::PredicateVariant(predicate));
+  this->add_variant_predicate(name, modulo_utils::PredicateVariant(predicate));
 }
 
 void ComponentInterface::add_predicate(const std::string& name, const std::function<bool(void)>& predicate) {
-  this->add_variant_predicate(name, utilities::PredicateVariant(predicate));
+  this->add_variant_predicate(name, modulo_utils::PredicateVariant(predicate));
 }
 
-void ComponentInterface::add_variant_predicate(const std::string& name, const utilities::PredicateVariant& predicate) {
+void ComponentInterface::add_variant_predicate(
+    const std::string& name, const modulo_utils::PredicateVariant& predicate) {
   if (name.empty()) {
     RCLCPP_ERROR(this->node_logging_->get_logger(), "Failed to add predicate: Provide a non empty string as a name.");
     return;
@@ -211,16 +212,17 @@ bool ComponentInterface::get_predicate(const std::string& predicate_name) {
 }
 
 void ComponentInterface::set_predicate(const std::string& name, bool predicate) {
-  this->set_variant_predicate(name, utilities::PredicateVariant(predicate));
+  this->set_variant_predicate(name, modulo_utils::PredicateVariant(predicate));
 }
 
 void ComponentInterface::set_predicate(
     const std::string& name, const std::function<bool(void)>& predicate
 ) {
-  this->set_variant_predicate(name, utilities::PredicateVariant(predicate));
+  this->set_variant_predicate(name, modulo_utils::PredicateVariant(predicate));
 }
 
-void ComponentInterface::set_variant_predicate(const std::string& name, const utilities::PredicateVariant& predicate) {
+void ComponentInterface::set_variant_predicate(
+    const std::string& name, const modulo_utils::PredicateVariant& predicate) {
   auto predicate_iterator = this->predicates_.find(name);
   if (predicate_iterator == this->predicates_.end()) {
     RCLCPP_ERROR_STREAM_THROTTLE(this->node_logging_->get_logger(), *this->node_clock_->get_clock(), 1000,
@@ -276,7 +278,7 @@ void ComponentInterface::declare_output(
 void ComponentInterface::declare_signal(
     const std::string& signal_name, const std::string& type, const std::string& default_topic, bool fixed_topic
 ) {
-  std::string parsed_signal_name = utilities::parse_topic_name(signal_name);
+  std::string parsed_signal_name = modulo_utils::parse_topic_name(signal_name);
   if (parsed_signal_name.empty()) {
     throw exceptions::AddSignalException(
         "The parsed signal name for " + type + " '" + signal_name
@@ -308,7 +310,7 @@ void ComponentInterface::declare_signal(
 }
 
 void ComponentInterface::publish_output(const std::string& signal_name) {
-  auto parsed_signal_name = utilities::parse_topic_name(signal_name);
+  auto parsed_signal_name = modulo_utils::parse_topic_name(signal_name);
   if (this->outputs_.find(parsed_signal_name) == this->outputs_.cend()) {
     throw exceptions::ComponentException("Output with name '" + signal_name + "' doesn't exist.");
   }
@@ -325,7 +327,7 @@ void ComponentInterface::publish_output(const std::string& signal_name) {
 
 void ComponentInterface::remove_input(const std::string& signal_name) {
   if (!this->remove_signal(signal_name, this->inputs_)) {
-    auto parsed_signal_name = utilities::parse_topic_name(signal_name);
+    auto parsed_signal_name = modulo_utils::parse_topic_name(signal_name);
     if (!this->remove_signal(parsed_signal_name, this->inputs_)) {
       RCLCPP_DEBUG_STREAM(this->node_logging_->get_logger(),
                           "Unknown input '" << signal_name << "' (parsed name was '" << parsed_signal_name << "').");
@@ -335,7 +337,7 @@ void ComponentInterface::remove_input(const std::string& signal_name) {
 
 void ComponentInterface::remove_output(const std::string& signal_name) {
   if (!this->remove_signal(signal_name, this->outputs_)) {
-    auto parsed_signal_name = utilities::parse_topic_name(signal_name);
+    auto parsed_signal_name = modulo_utils::parse_topic_name(signal_name);
     if (!this->remove_signal(parsed_signal_name, this->outputs_)) {
       RCLCPP_DEBUG_STREAM(this->node_logging_->get_logger(),
                           "Unknown output '" << signal_name << "' (parsed name was '" << parsed_signal_name << "').");
@@ -398,7 +400,7 @@ void ComponentInterface::add_service(
 }
 
 std::string ComponentInterface::validate_service_name(const std::string& service_name) {
-  std::string parsed_service_name = utilities::parse_topic_name(service_name);
+  std::string parsed_service_name = modulo_utils::parse_topic_name(service_name);
   if (parsed_service_name.empty()) {
     throw exceptions::AddServiceException(
         "The parsed service name for service '" + service_name

--- a/source/modulo_components/src/LifecycleComponent.cpp
+++ b/source/modulo_components/src/LifecycleComponent.cpp
@@ -9,7 +9,7 @@ namespace modulo_components {
 
 LifecycleComponent::LifecycleComponent(const rclcpp::NodeOptions& node_options, const std::string& fallback_name)
     : LifecycleNode(
-        utilities::parse_node_name(node_options, fallback_name), utilities::modify_parameter_overrides(node_options)),
+        modulo_utils::parse_node_name(node_options, fallback_name), utilities::modify_parameter_overrides(node_options)),
       ComponentInterface(std::make_shared<rclcpp::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES>>(
           LifecycleNode::get_node_base_interface(), LifecycleNode::get_node_clock_interface(),
           LifecycleNode::get_node_graph_interface(), LifecycleNode::get_node_logging_interface(),

--- a/source/modulo_utils/include/modulo_utils/parsing.hpp
+++ b/source/modulo_utils/include/modulo_utils/parsing.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace modulo_utils {
+
+/**
+ * @brief Parse a string node name from NodeOptions arguments.
+ * @param options The NodeOptions structure to parse
+ * @param fallback The default name if the NodeOptions structure cannot be parsed
+ * @return the parsed node name or the fallback name
+ */
+[[maybe_unused]] static std::string
+parse_node_name(const rclcpp::NodeOptions& options, const std::string& fallback = "") {
+  std::string node_name = fallback;
+  const std::string pattern("__node:=");
+  for (const auto& arg : options.arguments()) {
+    std::string::size_type index = arg.find(pattern);
+    if (index != std::string::npos) {
+      node_name = arg;
+      node_name.erase(index, pattern.length());
+      break;
+    }
+  }
+  return node_name;
+}
+
+/**
+ * @brief Parse a string topic name from a user-provided input.
+ * @details This functions removes all characters different from a-z, A-Z, 0-9, and _ from a string and transforms
+ * uppercase letters into lowercase letters. Additionally, it removes all leading numbers and underscores, such that the
+ * resulting string starts with a letter a-z.
+ * @param topic_name The input string
+ * @return the sanitized string
+ */
+[[maybe_unused]] static std::string parse_topic_name(const std::string& topic_name) {
+  std::string output;
+  for (char c : topic_name) {
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+      output.insert(output.end(), std::tolower(c));
+    } else if (!output.empty() && ((c >= '0' && c <= '9') || c == '_')) {
+      output.insert(output.end(), c);
+    }
+  }
+  return output;
+}
+
+}// namespace modulo_utils

--- a/source/modulo_utils/include/modulo_utils/predicate_variant.hpp
+++ b/source/modulo_utils/include/modulo_utils/predicate_variant.hpp
@@ -2,8 +2,8 @@
 
 #include <variant>
 
-namespace modulo_components::utilities {
+namespace modulo_utils {
 
 typedef std::variant<bool, std::function<bool(void)>> PredicateVariant;
 
-}// namespace modulo_components::utilities
+}// namespace modulo_components::modulo_utils

--- a/source/modulo_utils/modulo_utils/parsing.py
+++ b/source/modulo_utils/modulo_utils/parsing.py
@@ -1,0 +1,16 @@
+import re
+
+
+def parse_topic_name(topic_name: str) -> str:
+    """
+    Parse a string topic name from a user-provided input.
+    This functions removes all characters different from a-z, A-Z, 0-9, and _ from a string and transforms
+    uppercase letters into lowercase letters. Additionally, it removes all leading numbers and underscores, such that
+    the resulting string starts with a letter a-z.
+
+    :param topic_name: The input string
+    :return: The sanitized string
+    """
+    sanitized_string = re.sub("\W", "", topic_name, flags=re.ASCII).lower()
+    sanitized_string = sanitized_string.lstrip("0123456789_")
+    return sanitized_string


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
Since the code form the predicate variant and other utilities is currently duplicated between modulo components and controllers, it's reasonable to move that to the utils package.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->