### PR TITLE
feat: check that init of base class has been called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Release Versions:
 - feat: improve logging in parameter translators (#65)
 - fix(component-interface): make python subscriptions type safe (#71)
 - build: change base workspace image version
-- feat: add modulo controllers (#84, #93, #94, #95, #96, #97, #98)
+- feat: add modulo controllers (#84, #93, #94, #95, #96, #97, #98, #99)
 
 ## 4.1.0
 

--- a/source/modulo_controllers/include/modulo_controllers/ControllerInterface.hpp
+++ b/source/modulo_controllers/include/modulo_controllers/ControllerInterface.hpp
@@ -615,6 +615,7 @@ private:
   std::timed_mutex command_mutex_;
   // TODO make missed_locks an internal parameter
   unsigned int missed_locks_;
+  bool on_init_called_;
 };
 
 template<typename T>

--- a/source/modulo_controllers/src/ControllerInterface.cpp
+++ b/source/modulo_controllers/src/ControllerInterface.cpp
@@ -57,7 +57,8 @@ ControllerInterface::on_configure(const rclcpp_lifecycle::State&) {
   if (!on_init_called_) {
     RCLCPP_ERROR(
         get_node()->get_logger(),
-        "'ModuloControllerInterface::on_init()' has not been called, any derived class needs to do that");
+        "The controller has not been properly initialized! Derived controller classes must call "
+        "'ControllerInterface::on_init()' during their own initialization before being configured.");
     return CallbackReturn::ERROR;
   }
   auto hardware_name = get_parameter("hardware_name");


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
This is something that has bothered me a little bit for a while. If you check the modulo_controllers::ControllerInterface, you can see that all `on_XXX` transition callbacks are overridden, except the `on_init`. We chose to override that to assure that the base class `on_XXX` steps are always called, i.e. to not put the responsibility of putting `return ControllerInterface::on_XXX` into the derived class' callback onto the user.

However, this doesn't work with the `on_init` callback since it already has no arguments in the ros2 control base class. Meaning we now have mixed behavior where a derived class has to call the `on_init` of the parent explicitly, but not the other callbacks. One way that I can think of to remedy that is to check that the `on_init` has been called with a flag in the base class, as proposed here.

If you can see better solutions, I'd be happy to hear them.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->