### PR TITLE
fix(components): try catch subscription callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@ Release Versions:
 
 ## Upcoming changes
 
- - fix(components): remove incorrect log line (#166)
- - fix(controllers): move predicate publishing rate parameter to BaseControllerInterface (#168)
- - feat(components): get clproto message type from attribute (#175)
- - fix(components): add missing test case (#181)
- - fix(components): clean up lifecycle nodes properly (#178)
+- fix(components): remove incorrect log line (#166)
+- fix(controllers): move predicate publishing rate parameter to BaseControllerInterface (#168)
+- feat(components): get clproto message type from attribute (#175)
+- fix(components): add missing test case (#181)
+- fix(components): clean up lifecycle nodes properly (#178)
+- fix(components): try catch subscription callbacks (#167)
 
 ## 5.0.2
 

--- a/aica-package.toml
+++ b/aica-package.toml
@@ -1,7 +1,7 @@
 #syntax=ghcr.io/aica-technology/package-builder:v1.3.0
 
 [metadata]
-version = "5.1.0-rc0002"
+version = "5.1.0-rc0003"
 description = "Modular ROS 2 extension library for dynamic composition of components and controllers with the AICA robotics framework"
 
 [metadata.collection]

--- a/source/modulo_components/test/cpp/include/test_modulo_components/communication_components.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/communication_components.hpp
@@ -53,6 +53,32 @@ private:
 };
 
 template<class ComponentT>
+class ExceptionCartesianInput : public ComponentT {
+public:
+  ExceptionCartesianInput(const rclcpp::NodeOptions& node_options, const std::string& topic)
+      : ComponentT(node_options, "exception_cartesian_input"), thrown_(false) {
+    this->received_future = this->received_.get_future();
+    this->template add_input<modulo_core::EncodedState>(
+        "cartesian_state",
+        [this](const std::shared_ptr<modulo_core::EncodedState>) {
+          if (!this->thrown_) {
+            this->thrown_ = true;
+            throw std::runtime_error("Error");
+          } else {
+            this->received_.set_value();
+          }
+        },
+        topic);
+  }
+
+  std::shared_future<void> received_future;
+
+private:
+  bool thrown_;
+  std::promise<void> received_;
+};
+
+template<class ComponentT>
 class MinimalTwistOutput : public ComponentT {
 public:
   MinimalTwistOutput(

--- a/source/modulo_components/test/cpp/test_component_communication.cpp
+++ b/source/modulo_components/test/cpp/test_component_communication.cpp
@@ -33,6 +33,17 @@ TEST_F(ComponentCommunicationTest, InputOutput) {
   EXPECT_THROW(output_node->publish(), modulo_core::exceptions::CoreException);
 }
 
+TEST_F(ComponentCommunicationTest, ExceptionInputOutput) {
+  auto cartesian_state = state_representation::CartesianState::Random("test");
+  auto input_node = std::make_shared<ExceptionCartesianInput<Component>>(rclcpp::NodeOptions(), "/topic");
+  auto output_node =
+      std::make_shared<MinimalCartesianOutput<Component>>(rclcpp::NodeOptions(), "/topic", cartesian_state, true);
+  this->exec_->add_node(input_node);
+  this->exec_->add_node(output_node);
+  auto return_code = this->exec_->spin_until_future_complete(input_node->received_future, 500ms);
+  ASSERT_EQ(return_code, rclcpp::FutureReturnCode::SUCCESS);
+}
+
 TEST_F(ComponentCommunicationTest, InputOutputManual) {
   auto cartesian_state = state_representation::CartesianState::Random("test");
   auto input_node = std::make_shared<MinimalCartesianInput<Component>>(rclcpp::NodeOptions(), "/topic");

--- a/source/modulo_components/test/cpp/test_lifecycle_component_communication.cpp
+++ b/source/modulo_components/test/cpp/test_lifecycle_component_communication.cpp
@@ -33,6 +33,17 @@ TEST_F(LifecycleComponentCommunicationTest, InputOutput) {
   EXPECT_THROW(output_node->publish(), modulo_core::exceptions::CoreException);
 }
 
+TEST_F(LifecycleComponentCommunicationTest, ExceptionInputOutput) {
+  auto cartesian_state = state_representation::CartesianState::Random("test");
+  auto input_node = std::make_shared<ExceptionCartesianInput<LifecycleComponent>>(rclcpp::NodeOptions(), "/topic");
+  auto output_node = std::make_shared<MinimalCartesianOutput<LifecycleComponent>>(
+      rclcpp::NodeOptions(), "/topic", cartesian_state, true);
+  add_configure_activate(this->exec_, input_node);
+  add_configure_activate(this->exec_, output_node);
+  auto return_code = this->exec_->spin_until_future_complete(input_node->received_future, 500ms);
+  ASSERT_EQ(return_code, rclcpp::FutureReturnCode::SUCCESS);
+}
+
 TEST_F(LifecycleComponentCommunicationTest, InputOutputManual) {
   auto cartesian_state = state_representation::CartesianState::Random("test");
   auto input_node = std::make_shared<MinimalCartesianInput<LifecycleComponent>>(rclcpp::NodeOptions(), "/topic");

--- a/source/modulo_components/test/python/test_component_communication.py
+++ b/source/modulo_components/test/python/test_component_communication.py
@@ -16,6 +16,15 @@ def test_input_output(ros_exec, random_pose, minimal_cartesian_output, minimal_c
         minimal_cartesian_output.publish()
 
 
+@pytest.mark.parametrize("exception_cartesian_input", [[Component, "/topic"]], indirect=True)
+@pytest.mark.parametrize("minimal_cartesian_output", [[Component, "/topic", True]], indirect=True)
+def test_exception_input_output(ros_exec, minimal_cartesian_output, exception_cartesian_input):
+    ros_exec.add_node(exception_cartesian_input)
+    ros_exec.add_node(minimal_cartesian_output)
+    ros_exec.spin_until_future_complete(exception_cartesian_input.received_future, timeout_sec=0.5)
+    assert exception_cartesian_input.received_future.done() and exception_cartesian_input.received_future.result()
+
+
 @pytest.mark.parametrize("minimal_cartesian_input", [[Component, "/topic"]], indirect=True)
 @pytest.mark.parametrize("minimal_cartesian_output", [[Component, "/topic", False]], indirect=True)
 def test_input_output_manual(ros_exec, random_pose, minimal_cartesian_output, minimal_cartesian_input):

--- a/source/modulo_components/test/python/test_lifecycle_component_communication.py
+++ b/source/modulo_components/test/python/test_lifecycle_component_communication.py
@@ -25,6 +25,24 @@ def test_input_output(ros_exec, make_lifecycle_change_client, random_pose, minim
         minimal_cartesian_output.publish()
 
 
+@pytest.mark.parametrize("exception_cartesian_input", [[LifecycleComponent, "/topic"]], indirect=True)
+@pytest.mark.parametrize("minimal_cartesian_output", [[LifecycleComponent, "/topic", True]], indirect=True)
+def test_exception_input_output(
+        ros_exec, make_lifecycle_change_client, minimal_cartesian_output, exception_cartesian_input):
+    input_change_client = make_lifecycle_change_client("exception_cartesian_input")
+    output_change_client = make_lifecycle_change_client("minimal_cartesian_output")
+    ros_exec.add_node(input_change_client)
+    ros_exec.add_node(output_change_client)
+    ros_exec.add_node(exception_cartesian_input)
+    ros_exec.add_node(minimal_cartesian_output)
+    input_change_client.configure(ros_exec)
+    output_change_client.configure(ros_exec)
+    input_change_client.activate(ros_exec)
+    output_change_client.activate(ros_exec)
+    ros_exec.spin_until_future_complete(exception_cartesian_input.received_future, timeout_sec=0.5)
+    assert exception_cartesian_input.received_future.done() and exception_cartesian_input.received_future.result()
+
+
 @pytest.mark.parametrize("minimal_cartesian_input", [[LifecycleComponent, "/topic"]], indirect=True)
 @pytest.mark.parametrize("minimal_cartesian_output", [[LifecycleComponent, "/topic", False]], indirect=True)
 def test_input_output_manual(ros_exec, make_lifecycle_change_client, random_pose, minimal_cartesian_output,


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
This PR improves the robustness of the component interfaces by try catching subscription callbacks in all cases. Until now, we "only" try catched additional user callbacks.

One might argue that we should only catch `CoreException` and not all exceptions as the user might want to throw exceptions on purpose but I can not imagine a setup where one would desire to throw an exception in a subscription callback.

Also, we could put the component in error state by putting the `raise_error` there but that as well, I'm just not sure if I want to introduce it, since we'd have to do that consistently in all the `add_input` variants. I like the idea of subscription callbacks just failing with a throttled log instead of raising the error on the component.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->