### PR TITLE
feat(components): get clproto message type from attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Release Versions:
  - feat(controllers): add TF listener in BaseControllerInterface (#169)
  - feat(controllers): add TF broadcaster in BaseControllerInterface (#170)
  - test(controllers): add TF listener and broadcaster tests (#172)
+ - feat(components): get clproto message type from attribute (#175)
 
 ## 5.0.2
 

--- a/source/modulo_components/modulo_components/component.py
+++ b/source/modulo_components/modulo_components/component.py
@@ -1,5 +1,5 @@
 from threading import Thread
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 import clproto
 from modulo_components.component_interface import ComponentInterface
@@ -74,7 +74,7 @@ class Component(ComponentInterface):
         return True
 
     def add_output(self, signal_name: str, data: str, message_type: MsgT,
-                   clproto_message_type=clproto.MessageType.UNKNOWN_MESSAGE, default_topic="", fixed_topic=False,
+                   clproto_message_type: Optional[clproto.MessageType] = None, default_topic="", fixed_topic=False,
                    publish_on_step=True):
         """
         Add and configure an output signal of the component.

--- a/source/modulo_components/modulo_components/lifecycle_component.py
+++ b/source/modulo_components/modulo_components/lifecycle_component.py
@@ -1,4 +1,4 @@
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 import clproto
 from lifecycle_msgs.msg import State
@@ -361,7 +361,7 @@ class LifecycleComponent(ComponentInterface, LifecycleNodeMixin):
         return success
 
     def add_output(self, signal_name: str, data: str, message_type: MsgT,
-                   clproto_message_type=clproto.MessageType.UNKNOWN_MESSAGE, default_topic="", fixed_topic=False,
+                   clproto_message_type: Optional[clproto.MessageType] = None, default_topic="", fixed_topic=False,
                    publish_on_step=True):
         """
         Add an output signal of the component.

--- a/source/modulo_components/test/python/conftest.py
+++ b/source/modulo_components/test/python/conftest.py
@@ -49,8 +49,7 @@ def minimal_cartesian_output(request, random_pose):
 
         component = component_type("minimal_cartesian_output")
         component._output = random_pose
-        component.add_output("cartesian_pose", "_output", EncodedState, clproto.MessageType.CARTESIAN_STATE_MESSAGE,
-                             topic, publish_on_step=publish_on_step)
+        component.add_output("cartesian_pose", "_output", EncodedState, default_topic=topic, publish_on_step=publish_on_step)
         component.publish = publish.__get__(component)
         return component
 
@@ -65,8 +64,7 @@ def minimal_joint_output(request, random_joint):
 
         component = component_type("minimal_joint_output")
         component._output = random_joint
-        component.add_output("joint_state", "_output", EncodedState, clproto.MessageType.JOINT_STATE_MESSAGE,
-                             topic, publish_on_step=publish_on_step)
+        component.add_output("joint_state", "_output", EncodedState, default_topic=topic, publish_on_step=publish_on_step)
         component.publish = publish.__get__(component)
         return component
 

--- a/source/modulo_core/modulo_core/translators/message_writers.py
+++ b/source/modulo_core/modulo_core/translators/message_writers.py
@@ -14,6 +14,46 @@ MsgT = TypeVar('MsgT')
 StateT = TypeVar('StateT')
 
 
+def get_clproto_msg_type(state: StateT) -> clproto.MessageType:
+    if isinstance(state, sr.CartesianPose):
+        return clproto.MessageType.CARTESIAN_POSE_MESSAGE
+    elif isinstance(state, sr.CartesianTwist):
+        return clproto.MessageType.CARTESIAN_TWIST_MESSAGE
+    elif isinstance(state, sr.CartesianAcceleration):
+        return clproto.MessageType.CARTESIAN_ACCELERATION_MESSAGE
+    elif isinstance(state, sr.CartesianWrench):
+        return clproto.MessageType.CARTESIAN_WRENCH_MESSAGE
+    elif isinstance(state, sr.CartesianState):
+        return clproto.MessageType.CARTESIAN_STATE_MESSAGE
+    elif isinstance(state, sr.SpatialState):
+        return clproto.MessageType.SPATIAL_STATE_MESSAGE
+    elif isinstance(state, sr.JointPositions):
+        return clproto.MessageType.JOINT_POSITIONS_MESSAGE
+    elif isinstance(state, sr.JointVelocities):
+        return clproto.MessageType.JOINT_VELOCITIES_MESSAGE
+    elif isinstance(state, sr.JointAccelerations):
+        return clproto.MessageType.JOINT_VELOCITIES_MESSAGE
+    elif isinstance(state, sr.JointTorques):
+        return clproto.MessageType.JOINT_TORQUES_MESSAGE
+    elif isinstance(state, sr.JointState):
+        return clproto.MessageType.JOINT_STATE_MESSAGE
+    elif isinstance(state, sr.Parameter):
+        return clproto.MessageType.PARAMETER_MESSAGE
+    elif isinstance(state, sr.DigitalIOState):
+        return clproto.MessageType.DIGITAL_IO_STATE_MESSAGE
+    elif isinstance(state, sr.AnalogIOState):
+        return clproto.MessageType.ANALOG_IO_STATE_MESSAGE
+    elif isinstance(state, sr.Jacobian):
+        return clproto.MessageType.JACOBIAN_MESSAGE
+    elif isinstance(state, sr.Ellipsoid):
+        return clproto.MessageType.ELLIPSOID_MESSAGE
+    elif isinstance(state, sr.Shape):
+        return clproto.MessageType.SHAPE_MESSAGE
+    elif isinstance(state, sr.State):
+        return clproto.MessageType.STATE_MESSAGE
+    return clproto.MessageType.UNKNOWN_MESSAGE
+
+
 def write_xyz(message: Union[geometry.Point, geometry.Vector3], vector: np.array):
     """
     Helper function to write a vector to a Point or Vector3 message.

--- a/source/modulo_core/modulo_core/translators/message_writers.py
+++ b/source/modulo_core/modulo_core/translators/message_writers.py
@@ -15,42 +15,46 @@ StateT = TypeVar('StateT')
 
 
 def get_clproto_msg_type(state: StateT) -> clproto.MessageType:
-    if isinstance(state, sr.CartesianPose):
-        return clproto.MessageType.CARTESIAN_POSE_MESSAGE
-    elif isinstance(state, sr.CartesianTwist):
-        return clproto.MessageType.CARTESIAN_TWIST_MESSAGE
-    elif isinstance(state, sr.CartesianAcceleration):
-        return clproto.MessageType.CARTESIAN_ACCELERATION_MESSAGE
-    elif isinstance(state, sr.CartesianWrench):
-        return clproto.MessageType.CARTESIAN_WRENCH_MESSAGE
-    elif isinstance(state, sr.CartesianState):
-        return clproto.MessageType.CARTESIAN_STATE_MESSAGE
-    elif isinstance(state, sr.SpatialState):
-        return clproto.MessageType.SPATIAL_STATE_MESSAGE
-    elif isinstance(state, sr.JointPositions):
-        return clproto.MessageType.JOINT_POSITIONS_MESSAGE
-    elif isinstance(state, sr.JointVelocities):
-        return clproto.MessageType.JOINT_VELOCITIES_MESSAGE
-    elif isinstance(state, sr.JointAccelerations):
-        return clproto.MessageType.JOINT_VELOCITIES_MESSAGE
-    elif isinstance(state, sr.JointTorques):
-        return clproto.MessageType.JOINT_TORQUES_MESSAGE
-    elif isinstance(state, sr.JointState):
-        return clproto.MessageType.JOINT_STATE_MESSAGE
-    elif isinstance(state, sr.Parameter):
-        return clproto.MessageType.PARAMETER_MESSAGE
-    elif isinstance(state, sr.DigitalIOState):
-        return clproto.MessageType.DIGITAL_IO_STATE_MESSAGE
-    elif isinstance(state, sr.AnalogIOState):
-        return clproto.MessageType.ANALOG_IO_STATE_MESSAGE
-    elif isinstance(state, sr.Jacobian):
-        return clproto.MessageType.JACOBIAN_MESSAGE
-    elif isinstance(state, sr.Ellipsoid):
-        return clproto.MessageType.ELLIPSOID_MESSAGE
-    elif isinstance(state, sr.Shape):
-        return clproto.MessageType.SHAPE_MESSAGE
-    elif isinstance(state, sr.State):
+    if not isinstance(state, sr.State) or not hasattr(state, 'get_type') or not callable(state.get_type):
+        return clproto.MessageType.UNKNOWN_MESSAGE
+
+    state_type = state.get_type()
+    if state_type == sr.StateType.STATE:
         return clproto.MessageType.STATE_MESSAGE
+    elif state_type == sr.StateType.SPATIAL_STATE:
+        return clproto.MessageType.SPATIAL_STATE_MESSAGE
+    elif state_type == sr.StateType.CARTESIAN_STATE:
+        return clproto.MessageType.CARTESIAN_STATE_MESSAGE
+    elif state_type == sr.StateType.CARTESIAN_POSE:
+        return clproto.MessageType.CARTESIAN_POSE_MESSAGE
+    elif state_type == sr.StateType.CARTESIAN_TWIST:
+        return clproto.MessageType.CARTESIAN_TWIST_MESSAGE
+    elif state_type == sr.StateType.CARTESIAN_ACCELERATION:
+        return clproto.MessageType.CARTESIAN_ACCELERATION_MESSAGE
+    elif state_type == sr.StateType.CARTESIAN_WRENCH:
+        return clproto.MessageType.CARTESIAN_WRENCH_MESSAGE
+    elif state_type == sr.StateType.JACOBIAN:
+        return clproto.MessageType.JACOBIAN_MESSAGE
+    elif state_type == sr.StateType.JOINT_STATE:
+        return clproto.MessageType.JOINT_STATE_MESSAGE
+    elif state_type == sr.StateType.JOINT_POSITIONS:
+        return clproto.MessageType.JOINT_POSITIONS_MESSAGE
+    elif state_type == sr.StateType.JOINT_VELOCITIES:
+        return clproto.MessageType.JOINT_VELOCITIES_MESSAGE
+    elif state_type == sr.StateType.JOINT_ACCELERATIONS:
+        return clproto.MessageType.JOINT_ACCELERATIONS_MESSAGE
+    elif state_type == sr.StateType.JOINT_TORQUES:
+        return clproto.MessageType.JOINT_TORQUES_MESSAGE
+    elif state_type == sr.StateType.GEOMETRY_SHAPE:
+        return clproto.MessageType.SHAPE_MESSAGE
+    elif state_type == sr.StateType.GEOMETRY_ELLIPSOID:
+        return clproto.MessageType.ELLIPSOID_MESSAGE
+    elif state_type == sr.StateType.PARAMETER:
+        return clproto.MessageType.PARAMETER_MESSAGE
+    elif state_type == sr.StateType.DIGITAL_IO_STATE:
+        return clproto.MessageType.DIGITAL_IO_STATE_MESSAGE
+    elif state_type == sr.StateType.ANALOG_IO_STATE:
+        return clproto.MessageType.ANALOG_IO_STATE_MESSAGE
     return clproto.MessageType.UNKNOWN_MESSAGE
 
 


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
One thing that has come to my attention with the recent documentation efforts and webinars is that the fact that we require the user to know the mapping between state representation type and the clproto message type when adding an output in python is a bit too much. I propose here in a non breaking fashion to remedy that by getting the clproto message type from the type of the class attribute. The functionality stays exactly the same (e.g. existing code still works and if a user wants to publish a CartesianPose as a CARTESIAN_STATE_MESSAGE, that is still possible), but for the simple case of the 1:1 mapping, the clproto message type is not required anymore to add an output.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->