### PR TITLE
fix(controllers): reset previous joint commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Release Versions:
 - [2.1.1](#211)
 - [2.1.0](#210)
 
+## Upcoming changes
+
+- fix(controllers): reset previous joint commands (#211)
+
 ## 5.2.1
 
 ### May 15th, 2025

--- a/aica-package.toml
+++ b/aica-package.toml
@@ -9,7 +9,7 @@ name = "modulo"
 
 [build]
 type = "ros"
-image = "v2.0.2-jazzy"
+image = "v2.0.5-jazzy"
 
 [build.dependencies]
 "@aica/foss/control-libraries" = "v9.0.0"

--- a/source/modulo_controllers/include/modulo_controllers/RobotControllerInterface.hpp
+++ b/source/modulo_controllers/include/modulo_controllers/RobotControllerInterface.hpp
@@ -55,6 +55,12 @@ public:
    */
   CallbackReturn on_activate() override;
 
+  /**
+   * @copydoc modulo_controllers::ControllerInterface::on_deactivate()
+   * @details Reset the previous joint commands
+   */
+  CallbackReturn on_deactivate() override;
+
 protected:
   /**
    * @brief Access the joint state object.

--- a/source/modulo_controllers/src/RobotControllerInterface.cpp
+++ b/source/modulo_controllers/src/RobotControllerInterface.cpp
@@ -197,14 +197,9 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn RobotC
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn RobotControllerInterface::on_deactivate() {
-  if (!control_type_.empty()) {
-    if (control_type_ == hardware_interface::HW_IF_POSITION) {
-      for (std::size_t index = 0; index < joints_.size(); ++index) {
-        previous_joint_command_values_[index] = joint_state_.get_position(index);
-      }
-    } else {
-      std::fill(previous_joint_command_values_.begin(), previous_joint_command_values_.end(), 0.0);
-    }
+  if (!control_type_.empty() && control_type_ != hardware_interface::HW_IF_POSITION) {
+    std::fill(previous_joint_command_values_.begin(), previous_joint_command_values_.end(), 0.0);
+  }
   }
   RCLCPP_DEBUG(get_node()->get_logger(), "Deactivation of RobotControllerInterface successful");
   return CallbackReturn::SUCCESS;

--- a/source/modulo_controllers/src/RobotControllerInterface.cpp
+++ b/source/modulo_controllers/src/RobotControllerInterface.cpp
@@ -200,7 +200,6 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn RobotC
   if (!control_type_.empty() && control_type_ != hardware_interface::HW_IF_POSITION) {
     std::fill(previous_joint_command_values_.begin(), previous_joint_command_values_.end(), 0.0);
   }
-  }
   RCLCPP_DEBUG(get_node()->get_logger(), "Deactivation of RobotControllerInterface successful");
   return CallbackReturn::SUCCESS;
 }

--- a/source/modulo_controllers/src/RobotControllerInterface.cpp
+++ b/source/modulo_controllers/src/RobotControllerInterface.cpp
@@ -196,6 +196,20 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn RobotC
   return CallbackReturn::SUCCESS;
 }
 
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn RobotControllerInterface::on_deactivate() {
+  if (!control_type_.empty()) {
+    if (control_type_ == hardware_interface::HW_IF_POSITION) {
+      for (std::size_t index = 0; index < joints_.size(); ++index) {
+        previous_joint_command_values_[index] = joint_state_.get_position(index);
+      }
+    } else {
+      std::fill(previous_joint_command_values_.begin(), previous_joint_command_values_.end(), 0.0);
+    }
+  }
+  RCLCPP_DEBUG(get_node()->get_logger(), "Deactivation of RobotControllerInterface successful");
+  return CallbackReturn::SUCCESS;
+}
+
 controller_interface::return_type RobotControllerInterface::read_state_interfaces() {
   auto status = ControllerInterface::read_state_interfaces();
   if (status != controller_interface::return_type::OK) {


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- https://github.com/aica-technology/core/issues/216

<!-- Required: explain how the PR addresses the parent issue -->
Issue raised by @SprGrf. Upon reactivation, controllers have the previous commands buffered for command rate limiting, so we need to reset those in order to avoid unexpected and probably undesired movements upon reactivation.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->