### PR TITLE
feat(controllers): expose parameters from base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Release Versions:
 - [2.1.1](#211)
 - [2.1.0](#210)
 
+## Upcoming changes
+
+- feat(controllers): expose parameters from base class (#214)
+
 ## 5.2.2
 
 ### June 25th, 2025

--- a/source/modulo_controllers/controller_descriptions/modulo_controllers_base_controller_interface.json
+++ b/source/modulo_controllers/controller_descriptions/modulo_controllers_base_controller_interface.json
@@ -8,6 +8,13 @@
   "virtual": true,
   "parameters": [
     {
+      "display_name": "Input validity period",
+      "description": "The maximum age of an input state before discarding it as expired (in seconds)",
+      "parameter_name": "input_validity_period",
+      "parameter_type": "double",
+      "default_value": "1.0"
+    },
+    {
       "display_name": "Predicate publishing rate",
       "description": "The rate at which to publish controller predicates (in Hertz)",
       "parameter_name": "predicate_publishing_rate",
@@ -16,11 +23,21 @@
       "internal": true
     },
     {
-      "display_name": "Input validity period",
-      "description": "The maximum age of an input state before discarding it as expired (in seconds)",
-      "parameter_name": "input_validity_period",
-      "parameter_type": "double",
-      "default_value": "1.0"
+      "display_name": "Update rate",
+      "description": "The rate at which to evaluate the controller (in Hertz). Defaults to the controller manager rate if not set.",
+      "parameter_name": "update_rate",
+      "parameter_type": "int",
+      "default_value": null,
+      "optional": true,
+      "internal": true
+    },
+    {
+      "display_name": "Is Async",
+      "description": "Whether the controller should be evaluated asynchronously",
+      "parameter_name": "is_async",
+      "parameter_type": "bool",
+      "default_value": "false",
+      "internal": true
     }
   ]
 }

--- a/source/modulo_controllers/src/BaseControllerInterface.cpp
+++ b/source/modulo_controllers/src/BaseControllerInterface.cpp
@@ -31,6 +31,13 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn BaseCo
       [this](const std::vector<rclcpp::Parameter>& parameters) -> rcl_interfaces::msg::SetParametersResult {
         return this->on_set_parameters_callback(parameters);
       });
+
+  // these two parameters are declared in the ControllerInterface, need to add them in the internal map as well
+  parameter_map_.set_parameter(std::make_shared<Parameter<int>>("update_rate"));
+  read_only_parameters_.insert_or_assign("update_rate", false);
+  parameter_map_.set_parameter(std::make_shared<Parameter<bool>>("is_async", false));
+  read_only_parameters_.insert_or_assign("is_async", false);
+
   add_parameter<double>("predicate_publishing_rate", 10.0, "The rate at which to publish controller predicates");
   add_parameter<double>(
       "input_validity_period", 1.0, "The maximum age of an input state before discarding it as expired");


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
<!-- Required: explain how the PR addresses the parent issue -->
The controller base class from ROS has two parameters `update_rate` and `is_async`. https://github.com/ros-controls/ros2_control/blob/aefbad38e4371aff499c39f53c8b296a557142cd/controller_interface/src/controller_interface_base.cpp#L37

Because of how our add/set parameter logic works, it is currently not possible to set those parameters on the node because the modulo base class doesn't know about them. By adding them to the internal parameter map, it becomes possible to set them (and not fail validation). For the `is_async` this is all good.

For the `update_rate` it is slightly more annoying because we usually use the name `rate` and type `double` for this. Keeping in mind that I marked both parameters internal, do you want me to investigate further how we could handle this? It would most likely be yet another parameter that we can then map to `update_rate` but it's not sure this is a clean and smooth solution.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->