### PR TITLE
Revert "fix: revert ABI breaking addition of assignments in C++ (#239)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Release Versions:
 - feat(controllers): use parent node for tf listener (#190)
 - refactor(interfaces)!: remove type from predicate collection message (#222)
 - chore: harmonize parameter validation messages (#251)
+- feat: add assignments in c++ (#221)
 
 ## 5.4.1
 

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -17,6 +17,7 @@
 #include <modulo_core/exceptions.hpp>
 #include <modulo_core/translators/parameter_translators.hpp>
 
+#include <modulo_interfaces/msg/assignment.hpp>
 #include <modulo_interfaces/msg/predicate_collection.hpp>
 #include <modulo_interfaces/srv/empty_trigger.hpp>
 #include <modulo_interfaces/srv/string_trigger.hpp>
@@ -161,6 +162,34 @@ protected:
    */
   virtual bool
   on_validate_parameter_callback(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
+
+  /**
+   * @brief Add an assignment to the map of assignments.
+   * @tparam T The type of the assignment
+   * @param assignment_name the name of the associated assignment
+   */
+  template<typename T>
+  void add_assignment(const std::string& assignment_name);
+
+  /**
+   * @brief Set the value of an assignment.
+   * @tparam T The type of the assignment   
+   * @param assignment_name The name of the assignment to set
+   * @param assignment_value The value of the assignment
+   */
+  template<typename T>
+  void set_assignment(const std::string& assignment_name, const T& assignment_value);
+
+  /**
+   * @brief Get the value of an assignment.
+   * @tparam T The type of the assignment   
+   * @param assignment_name The name of the assignment to get
+   * @throws modulo_core::exceptions::InvalidAssignmentException if the assignment does not exist or the type does not 
+     match
+     @throws state_representation::exceptions::EmptyStateException if the assignment has not been set yet 
+   */
+  template<typename T>
+  T get_assignment(const std::string& assignment_name) const;
 
   /**
    * @brief Add a predicate to the map of predicates.
@@ -554,6 +583,9 @@ private:
   modulo_interfaces::msg::PredicateCollection predicate_message_;
   std::vector<std::string> triggers_;///< List of triggers
 
+  state_representation::ParameterMap assignments_map_;                                         ///< Map of assignments
+  std::shared_ptr<rclcpp::Publisher<modulo_interfaces::msg::Assignment>> assignment_publisher_;///< Assignment publisher
+
   std::map<std::string, std::shared_ptr<rclcpp::Service<modulo_interfaces::srv::EmptyTrigger>>>
       empty_services_;///< Map of EmptyTrigger services
   std::map<std::string, std::shared_ptr<rclcpp::Service<modulo_interfaces::srv::StringTrigger>>>
@@ -818,6 +850,81 @@ inline void ComponentInterface::publish_transforms(
     RCLCPP_ERROR_STREAM_THROTTLE(
         this->node_logging_->get_logger(), *this->node_clock_->get_clock(), 1000,
         "Failed to send " << modifier << "transform: " << ex.what());
+  }
+}
+
+template<typename T>
+inline void ComponentInterface::add_assignment(const std::string& assignment_name) {
+  std::string parsed_name = modulo_utils::parsing::parse_topic_name(assignment_name);
+  if (parsed_name.empty()) {
+    RCLCPP_ERROR_STREAM(
+        this->node_logging_->get_logger(),
+        "The parsed name for assignment '" + assignment_name
+            + "' is empty. Provide a string with valid characters for the assignment name ([a-z0-9_]).");
+    return;
+  }
+  if (assignment_name != parsed_name) {
+    RCLCPP_WARN_STREAM(
+        this->node_logging_->get_logger(),
+        "The parsed name for assignment '" + assignment_name + "' is '" + parsed_name
+            + "'. Use the parsed name to refer to this assignment.");
+  }
+  try {
+    this->assignments_map_.get_parameter(parsed_name);
+    RCLCPP_WARN_STREAM(
+        this->node_logging_->get_logger(), "Assignment with name '" + parsed_name + "' already exists, overwriting.");
+  } catch (const state_representation::exceptions::InvalidParameterException& ex) {
+    RCLCPP_DEBUG_STREAM(this->node_logging_->get_logger(), "Adding assignment '" << parsed_name << "'.");
+  }
+  try {
+    assignments_map_.set_parameter(state_representation::make_shared_parameter<T>(parsed_name));
+  } catch (const std::exception& ex) {
+    RCLCPP_ERROR_STREAM_THROTTLE(
+        this->node_logging_->get_logger(), *this->node_clock_->get_clock(), 1000,
+        "Failed to add assignment '" << parsed_name << "': " << ex.what());
+  }
+}
+
+template<typename T>
+void ComponentInterface::set_assignment(const std::string& assignment_name, const T& assignment_value) {
+  modulo_interfaces::msg::Assignment message;
+  std::shared_ptr<state_representation::ParameterInterface> assignment;
+  try {
+    assignment = this->assignments_map_.get_parameter(assignment_name);
+  } catch (const state_representation::exceptions::InvalidParameterException&) {
+    RCLCPP_ERROR_STREAM_THROTTLE(
+        this->node_logging_->get_logger(), *this->node_clock_->get_clock(), 1000,
+        "Failed to set assignment '" << assignment_name << "': Assignment does not exist.");
+    return;
+  }
+  try {
+    assignment->set_parameter_value<T>(assignment_value);
+  } catch (const state_representation::exceptions::InvalidParameterCastException&) {
+    RCLCPP_ERROR_STREAM_THROTTLE(
+        this->node_logging_->get_logger(), *this->node_clock_->get_clock(), 1000,
+        "Failed to set assignment '" << assignment_name << "': Incompatible value type.");
+    return;
+  }
+  message.node = this->node_base_->get_fully_qualified_name();
+  message.assignment = modulo_core::translators::write_parameter(assignment).to_parameter_msg();
+  this->assignment_publisher_->publish(message);
+}
+
+template<typename T>
+T ComponentInterface::get_assignment(const std::string& assignment_name) const {
+  std::shared_ptr<state_representation::ParameterInterface> assignment;
+  try {
+    assignment = this->assignments_map_.get_parameter(assignment_name);
+  } catch (const state_representation::exceptions::InvalidParameterException&) {
+    throw modulo_core::exceptions::InvalidAssignmentException(
+        "Failed to get value of assignment '" + assignment_name + "': Assignment does not exist.");
+  }
+  try {
+    return assignment->get_parameter_value<T>();
+  } catch (const state_representation::exceptions::InvalidParameterCastException&) {
+    auto expected_type = state_representation::get_parameter_type_name(assignment->get_parameter_type());
+    throw modulo_core::exceptions::InvalidAssignmentException(
+        "Incompatible type for assignment '" + assignment_name + "' defined with type '" + expected_type + "'.");
   }
 }
 }// namespace modulo_components

--- a/source/modulo_components/src/ComponentInterface.cpp
+++ b/source/modulo_components/src/ComponentInterface.cpp
@@ -28,6 +28,9 @@ ComponentInterface::ComponentInterface(
       });
   this->add_parameter("rate", 10.0, "The rate in Hertz for all periodic callbacks", true);
 
+  this->assignment_publisher_ = rclcpp::create_publisher<modulo_interfaces::msg::Assignment>(
+      this->node_parameters_, this->node_topics_, "/assignments", this->qos_);
+
   this->predicate_publisher_ = rclcpp::create_publisher<modulo_interfaces::msg::PredicateCollection>(
       this->node_parameters_, this->node_topics_, "/predicates", this->qos_);
   this->predicate_message_.node = this->node_base_->get_fully_qualified_name();

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -21,6 +21,7 @@ public:
   using ComponentInterface::add_input;
   using ComponentInterface::add_parameter;
   using ComponentInterface::add_predicate;
+  using ComponentInterface::add_assignment;
   using ComponentInterface::add_service;
   using ComponentInterface::add_static_tf_broadcaster;
   using ComponentInterface::add_tf_broadcaster;
@@ -30,6 +31,7 @@ public:
   using ComponentInterface::declare_input;
   using ComponentInterface::declare_output;
   using ComponentInterface::empty_services_;
+  using ComponentInterface::get_assignment;
   using ComponentInterface::get_parameter;
   using ComponentInterface::get_parameter_value;
   using ComponentInterface::get_predicate;
@@ -44,6 +46,7 @@ public:
   using ComponentInterface::parameter_map_;
   using ComponentInterface::periodic_outputs_;
   using ComponentInterface::predicates_;
+  using ComponentInterface::assignments_map_;
   using ComponentInterface::publish_output;
   using ComponentInterface::raise_error;
   using ComponentInterface::remove_input;
@@ -51,6 +54,7 @@ public:
   using ComponentInterface::send_static_transforms;
   using ComponentInterface::send_transform;
   using ComponentInterface::send_transforms;
+  using ComponentInterface::set_assignment;
   using ComponentInterface::set_parameter_value;
   using ComponentInterface::set_predicate;
   using ComponentInterface::set_qos;

--- a/source/modulo_controllers/include/modulo_controllers/BaseControllerInterface.hpp
+++ b/source/modulo_controllers/include/modulo_controllers/BaseControllerInterface.hpp
@@ -22,6 +22,7 @@
 #include <modulo_core/translators/message_writers.hpp>
 #include <modulo_core/translators/parameter_translators.hpp>
 
+#include <modulo_interfaces/msg/assignment.hpp>
 #include <modulo_interfaces/msg/predicate_collection.hpp>
 #include <modulo_interfaces/srv/empty_trigger.hpp>
 #include <modulo_interfaces/srv/string_trigger.hpp>
@@ -192,6 +193,34 @@ protected:
    */
   template<typename T>
   void set_parameter_value(const std::string& name, const T& value);
+
+  /**
+   * @brief Add an assignment to the map of assignments.
+   * @tparam T The type of the assignment
+   * @param assignment_name the name of the associated assignment
+   */
+  template<typename T>
+  void add_assignment(const std::string& assignment_name);
+
+  /**
+   * @brief Set an assignment.
+   * @tparam T The type of the assignment   
+   * @param assignment_name The name of the assignment to publish
+   * @param assignment_value The value of the assignment
+   */
+  template<typename T>
+  void set_assignment(const std::string& assignment_name, const T& assignment_value);
+
+  /**
+   * @brief Get the value of an assignment.
+   * @tparam T The type of the assignment value   
+   * @param assignment_name The name of the assignment to get
+   * @throws modulo_core::exceptions::InvalidAssignmentException if the assignment does not exist or the type does not 
+     match
+     @throws state_representation::exceptions::EmptyStateException if the assignment has not been set yet 
+   */
+  template<typename T>
+  T get_assignment(const std::string& assignment_name) const;
 
   /**
    * @brief Add a predicate to the map of predicates.
@@ -588,6 +617,9 @@ private:
       empty_services_;///< Map of EmptyTrigger services
   std::map<std::string, std::shared_ptr<rclcpp::Service<modulo_interfaces::srv::StringTrigger>>>
       string_services_;///< Map of StringTrigger services
+
+  state_representation::ParameterMap assignments_map_;                                         ///< Map of assignments
+  std::shared_ptr<rclcpp::Publisher<modulo_interfaces::msg::Assignment>> assignment_publisher_;///< Assignment publisher
 
   std::map<std::string, modulo_core::Predicate> predicates_;///< Map of predicates
   std::shared_ptr<rclcpp::Publisher<modulo_interfaces::msg::PredicateCollection>>
@@ -1050,6 +1082,87 @@ BaseControllerInterface::create_service(const std::string& service_name, const s
     }
   } catch (const std::exception& ex) {
     RCLCPP_ERROR(get_node()->get_logger(), "Failed to add service '%s': %s", parsed_service_name.c_str(), ex.what());
+  }
+}
+
+template<typename T>
+inline void BaseControllerInterface::add_assignment(const std::string& assignment_name) {
+  std::string parsed_name = modulo_utils::parsing::parse_topic_name(assignment_name);
+  if (parsed_name.empty()) {
+    RCLCPP_ERROR_STREAM(
+        get_node()->get_logger(),
+        "The parsed name for assignment '" + assignment_name
+            + "' is empty. Provide a string with valid characters for the assignment name ([a-z0-9_]).");
+    return;
+  }
+  if (assignment_name != parsed_name) {
+    RCLCPP_WARN_STREAM(
+        get_node()->get_logger(),
+        "The parsed name for assignment '" + assignment_name + "' is '" + parsed_name
+            + "'. Use the parsed name to refer to this assignment.");
+  }
+  try {
+    this->assignments_map_.get_parameter(parsed_name);
+    RCLCPP_WARN_STREAM(
+        get_node()->get_logger(), "Assignment with name '" + parsed_name + "' already exists, overwriting.");
+  } catch (const state_representation::exceptions::InvalidParameterException& ex) {
+    RCLCPP_DEBUG_STREAM(get_node()->get_logger(), "Adding assignment '" << parsed_name << "'.");
+  }
+  try {
+    assignments_map_.set_parameter(state_representation::make_shared_parameter<T>(parsed_name));
+  } catch (const std::exception& ex) {
+    RCLCPP_ERROR_STREAM_THROTTLE(
+        get_node()->get_logger(), *get_node()->get_clock(), 1000,
+        "Failed to add assignment '" << parsed_name << "': " << ex.what());
+  }
+}
+
+template<typename T>
+inline void BaseControllerInterface::set_assignment(const std::string& assignment_name, const T& assignment_value) {
+  modulo_interfaces::msg::Assignment message;
+  std::shared_ptr<state_representation::ParameterInterface> assignment;
+  try {
+    assignment = assignments_map_.get_parameter(assignment_name);
+  } catch (const state_representation::exceptions::InvalidParameterException&) {
+    RCLCPP_ERROR_STREAM_THROTTLE(
+        get_node()->get_logger(), *get_node()->get_clock(), 1000,
+        "Failed to set assignment '" << assignment_name << "': Assignment does not exist.");
+    return;
+  }
+  try {
+    assignment->set_parameter_value<T>(assignment_value);
+  } catch (const state_representation::exceptions::InvalidParameterCastException&) {
+    RCLCPP_ERROR_STREAM_THROTTLE(
+        get_node()->get_logger(), *get_node()->get_clock(), 1000,
+        "Failed to set assignment '" << assignment_name << "': Incompatible value type.");
+    return;
+  }
+  if (assignment_publisher_ == nullptr) {
+    RCLCPP_ERROR_STREAM_THROTTLE(
+        get_node()->get_logger(), *get_node()->get_clock(), 1000,
+        "No assignment publisher configured. Make sure to add assignments `on_init` of the controller.");
+    return;
+  }
+  message.node = get_node()->get_fully_qualified_name();
+  message.assignment = modulo_core::translators::write_parameter(assignment).to_parameter_msg();
+  assignment_publisher_->publish(message);
+}
+
+template<typename T>
+inline T BaseControllerInterface::get_assignment(const std::string& assignment_name) const {
+  std::shared_ptr<state_representation::ParameterInterface> assignment;
+  try {
+    assignment = assignments_map_.get_parameter(assignment_name);
+  } catch (const state_representation::exceptions::InvalidParameterException&) {
+    throw modulo_core::exceptions::InvalidAssignmentException(
+        "Failed to get value of assignment '" + assignment_name + "': Assignment does not exist.");
+  }
+  try {
+    return assignment->get_parameter_value<T>();
+  } catch (const state_representation::exceptions::InvalidParameterCastException&) {
+    auto expected_type = state_representation::get_parameter_type_name(assignment->get_parameter_type());
+    throw modulo_core::exceptions::InvalidAssignmentException(
+        "Incompatible type for assignment '" + assignment_name + "' defined with type '" + expected_type + "'.");
   }
 }
 

--- a/source/modulo_controllers/src/BaseControllerInterface.cpp
+++ b/source/modulo_controllers/src/BaseControllerInterface.cpp
@@ -60,6 +60,9 @@ BaseControllerInterface::on_configure(const rclcpp_lifecycle::State&) {
         std::chrono::nanoseconds(static_cast<int64_t>(1e9 / get_parameter_value<double>("predicate_publishing_rate"))),
         [this]() { this->publish_predicates(); });
   }
+  if (assignments_map_.get_parameters().size()) {
+    assignment_publisher_ = get_node()->create_publisher<modulo_interfaces::msg::Assignment>("/assignments", qos_);
+  }
 
   RCLCPP_DEBUG(get_node()->get_logger(), "Configuration of BaseControllerInterface successful");
   return CallbackReturn::SUCCESS;

--- a/source/modulo_core/include/modulo_core/exceptions.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions.hpp
@@ -43,6 +43,16 @@ public:
 };
 
 /**
+ * @class InvalidAssignmentException
+ * @brief An exception class to notify errors when getting the value of an assignment.
+ * @details This is an exception class to be thrown if there is a problem while getting the value of an assignment in a modulo class.
+ */
+class InvalidAssignmentException : public CoreException {
+public:
+  explicit InvalidAssignmentException(const std::string& msg) : CoreException("InvalidAssignmentException", msg) {}
+};
+
+/**
  * @class InvalidPointerCastException
  * @brief An exception class to notify if the result of getting an instance of a derived class through dynamic
  * down-casting of an object of the base class is not a correctly typed instance of the derived class.


### PR DESCRIPTION
This reverts commit bd32dbbbd83a0fa5825fbb237408ca3ee8c45fb5.

<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
Bringing back the reverted assignment methods in C++ classes

<!-- Required: explain how the PR addresses the parent issue -->

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 3 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->